### PR TITLE
fix: remove FileType event on filetype component

### DIFF
--- a/lua/yasl/builtins/filetype.lua
+++ b/lua/yasl/builtins/filetype.lua
@@ -2,32 +2,32 @@ local icon_cache = {}
 
 return {
 	name = "filetype",
-	events = { "FileType", "BufEnter", "WinEnter" },
+	events = { "BufEnter", "WinEnter" },
 	update = function()
-		local ft = vim.bo.filetype
+		local filename = vim.fn.expand("%:t")
 
 		-- caching
 		-- todo: clean up hl stuff
-		if _YaslConfig.global_settings.enable_icons and not icon_cache[ft] then
+		if _YaslConfig.global_settings.enable_icons and not icon_cache[filename] then
 			local icon, hl = require("nvim-web-devicons").get_icon_colors(
-				vim.fn.expand("%:t"), -- need filename so nvim-web-devicons can compute it
+				filename,
 				nil
 			)
-			local hl_group = "Yasl" .. ft
+			local hl_group = "Yasl" .. filename
 
 			vim.api.nvim_set_hl(0, hl_group, {
 				fg = hl,
 				bg = vim.api.nvim_get_hl(0, { name = "StatusLine" }).bg
 			})
 
-			icon_cache[ft] = {
+			icon_cache[filename] = {
 				icon = icon,
 				hl_group = hl_group,
 			}
 		end
 
 		if _YaslConfig.global_settings.enable_icons then
-			return string.format("%%#%s#%s%%* ", icon_cache[ft].hl_group, icon_cache[ft].icon or "")
+			return string.format("%%#%s#%s%%* ", icon_cache[filename].hl_group, icon_cache[filename].icon or "")
 		else
 			return "%y"
 		end


### PR DESCRIPTION
Remove FileType event that causes ft icon to disappear when triggered by windows without names.